### PR TITLE
Remove dependency on 2 different esptool's. Also add gitignore for genererated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+firmware/

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ LD		:= $(XTENSA_TOOLS_ROOT)/xtensa-lx106-elf-gcc
 ####
 #### no user configurable options below here
 ####
-FW_TOOL		?= ../esptool/esptool
+FW_TOOL		?= $(ESPTOOL)
 SRC_DIR		:= $(MODULES)
 BUILD_DIR	:= $(addprefix $(BUILD_BASE)/,$(MODULES))
 
@@ -106,11 +106,11 @@ all: checkdirs $(TARGET_OUT) $(FW_FILE_1) $(FW_FILE_2)
 
 $(FW_FILE_1): $(TARGET_OUT)
 	$(vecho) "FW $@"
-	$(Q) $(FW_TOOL) -eo $(TARGET_OUT) $(FW_FILE_1_ARGS)
+	$(FW_TOOL) elf2image $< -o $(FW_BASE)/
 
 $(FW_FILE_2): $(TARGET_OUT)
 	$(vecho) "FW $@"
-	$(Q) $(FW_TOOL) -eo $(TARGET_OUT) $(FW_FILE_2_ARGS)
+	$(FW_TOOL) elf2image $< -o $(FW_BASE)/
 
 $(TARGET_OUT): $(APP_AR)
 	$(vecho) "LD $@"


### PR DESCRIPTION
We can use esptool.py itself to create the firmware files. This should remove the need to setup "esptool" separately just for this purpose.
Also added gitignore for generated files.
